### PR TITLE
reuse 选择2时的一个bug修复方案

### DIFF
--- a/lib/xctest-client.js
+++ b/lib/xctest-client.js
@@ -6,6 +6,7 @@ const iOSUtils = require('ios-utils');
 const detect = require('detect-port');
 const EventEmitter = require('events');
 const childProcess = require('child_process');
+const moment = require('moment');
 
 const _ = require('./helper');
 const pkg = require('../package');
@@ -16,6 +17,7 @@ const XCTestWD = require('./xctestwd');
 const TEST_URL = pkg.site;
 const projectPath = XCTestWD.projectPath;
 const SERVER_URL_REG = XCTestWD.SERVER_URL_REG;
+const TIME_REG = /(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d/;
 
 class XCTest extends EventEmitter {
   constructor(options) {
@@ -27,6 +29,7 @@ class XCTest extends EventEmitter {
     this.deviceLogProc = null;
     this.runnerProc = null;
     this.iproxyProc = null;
+    this.moment = null;
     Object.assign(this, {
       proxyHost: '127.0.0.1',
       proxyPort: 8001,
@@ -127,7 +130,9 @@ class XCTest extends EventEmitter {
         if (match) {
           const url = match[1];
           if (url.startsWith('http://')) {
-            resolve();
+            if (TIME_REG.exec(data)[0] > this.moment) {
+              resolve();
+            }
           }
         }
         // logger.debug(data);
@@ -145,6 +150,7 @@ class XCTest extends EventEmitter {
         logger.warn(`devicelog exit with code: ${code}, signal: ${signal}`);
         reject();
       });
+      this.moment = moment().format('H:mm:ss');
       this.startBootstrap();
     });
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jshint": "*",
     "macaca-utils": "^0.1.8",
     "mocha": "*",
+    "moment": "^2.18.1",
     "pre-commit": "1.1.1",
     "should": "*"
   },


### PR DESCRIPTION
在devicelog模块获取iOS真机设备日志的时候，发现它会将近一个小时的日志获取到，如果这些旧日志包含了关键字  XCTestWDSetup->（*）<-XCTestWDSetup ，那么macaca-ios就会开始发送 “ /wd/hub/session:POST to http://127.0.0.1:8001/wd/hub/session:POST ” ；事实上，这个时机是不正确的，正确的时机应该是最近的一次XCTestWD.xcodeproj构建成功并启动时打印的XCTRunner[2580] <Warning>: XCTestWDSetup->http://localhost:8001<-XCTestWDSetup 日志

我的解决办法是：最新的XCTestWD.xcodeproj构建时，记录一个时间戳，当匹配到XCTestWDSetup->（*）<-XCTestWDSetup日志时，判断一下这行日志的时间戳是不是晚于记录的时间戳，如果是，才执行resolve()； 当然，我这种办法在跨零点时，会有一些小问题；

@xdf ， 如果devicelog模块在启动时，能够先clear一下日志，这个问题就可以完美解决了