### PR TITLE
Update xctest-client.js

### DIFF
--- a/lib/xctest-client.js
+++ b/lib/xctest-client.js
@@ -17,7 +17,7 @@ const XCTestWD = require('./xctestwd');
 const TEST_URL = pkg.site;
 const projectPath = XCTestWD.projectPath;
 const SERVER_URL_REG = XCTestWD.SERVER_URL_REG;
-const TIME_REG = /(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d/;
+const TIME_REG = XCTestWD.TIME_REG;
 
 class XCTest extends EventEmitter {
   constructor(options) {
@@ -122,15 +122,15 @@ class XCTest extends EventEmitter {
     proc.stderr.setEncoding('utf8');
     proc.stdout.setEncoding('utf8');
 
-    yield this.startIproxy();
-
     return new Promise((resolve, reject) => {
       proc.stdout.on('data', data => {
         let match = SERVER_URL_REG.exec(data);
         if (match) {
           const url = match[1];
           if (url.startsWith('http://')) {
-            if (TIME_REG.exec(data)[0] > this.moment) {
+            let lasthit = moment(TIME_REG.exec(data)[0], 'MMM D HH:mm:ss').format('x');
+            if (lasthit > this.moment) {
+              this.configUrl(url);
               resolve();
             }
           }
@@ -150,7 +150,7 @@ class XCTest extends EventEmitter {
         logger.warn(`devicelog exit with code: ${code}, signal: ${signal}`);
         reject();
       });
-      this.moment = moment().format('H:mm:ss');
+      this.moment = moment().format('x');
       this.startBootstrap();
     });
   }
@@ -233,6 +233,8 @@ class XCTest extends EventEmitter {
 
       if (deviceInfo.isRealIOS) {
         yield this.startDeviceLog();
+        yield this.startIproxy();
+        yield _.sleep(3000);
       } else {
         yield this.startSimLog();
       }


### PR DESCRIPTION
1. 正则过滤/XCTestWDSetup->(.*)<-XCTestWDSetup/;的优化
2. startDeviceLog增加对this.configUrl(url);的调用，是macaca server使用XCTestWD返回的端口