### PR TITLE
让isVisible为false的控件不展示在界面

### DIFF
--- a/XCTestWD/XCTestWDUITests/server/models/extensions/XCTestWDAccessibility.swift
+++ b/XCTestWD/XCTestWDUITests/server/models/extensions/XCTestWDAccessibility.swift
@@ -275,19 +275,14 @@ extension XCUIElement {
             var children = [AnyObject]()
             for child in childrenElements! {
                 let tempchild=child as! XCElementSnapshot
-                if tempchild.isWDVisible()
-                {
+                if tempchild.isWDVisible() {
                     children.append(dictionaryForElement(child as! XCElementSnapshot) as AnyObject)
                 }
-
             }
-            if !children.isEmpty
-            {
+            if !children.isEmpty {
                 info["children"] = children as AnyObject
             }
-
         }
-        
         return info
     }
     

--- a/XCTestWD/XCTestWDUITests/server/models/extensions/XCTestWDAccessibility.swift
+++ b/XCTestWD/XCTestWDUITests/server/models/extensions/XCTestWDAccessibility.swift
@@ -268,16 +268,24 @@ extension XCUIElement {
         info["rect"] = snapshot.wdRect() as AnyObject
         info["frame"] = NSStringFromCGRect(snapshot.wdFrame()) as AnyObject
         info["isEnabled"] = snapshot.isWDEnabled() as AnyObject
-        info["isVisible"] = snapshot.isWDEnabled() as AnyObject
+        info["isVisible"] = snapshot.isWDVisible() as AnyObject
         
         let childrenElements = snapshot.children
         if childrenElements != nil && childrenElements!.count > 0 {
             var children = [AnyObject]()
             for child in childrenElements! {
-                children.append(dictionaryForElement(child as! XCElementSnapshot) as AnyObject)
+                let tempchild=child as! XCElementSnapshot
+                if tempchild.isWDVisible()
+                {
+                    children.append(dictionaryForElement(child as! XCElementSnapshot) as AnyObject)
+                }
+
             }
-            
-            info["children"] = children as AnyObject
+            if !children.isEmpty
+            {
+                info["children"] = children as AnyObject
+            }
+
         }
         
         return info


### PR DESCRIPTION
让isVisible为false的控件不展示在界面，减少录制回放时候的数据量，提升录制时候的准备和体验