### PR TITLE
设置XCTESTWD framework使用XCTESTWD_PORT

### DIFF
--- a/XCTestWD/XCTestWD.xcodeproj/project.pbxproj
+++ b/XCTestWD/XCTestWD.xcodeproj/project.pbxproj
@@ -1034,7 +1034,7 @@
 					"$(SDKROOT)/../../Library/Frameworks",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=8001";
+				GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=$(XCTESTWD_PORT)";
 				HEADER_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(SRCROOT)/",
@@ -1087,7 +1087,7 @@
 					"$(SDKROOT)/../../Library/Frameworks",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=8001";
+				GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=$(XCTESTWD_PORT)";
 				HEADER_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(SRCROOT)/",


### PR DESCRIPTION
项目模块化改造后，使用xcodebuild启动时设置的XCTESTWD_PORT 不起作用，应对XCTESTWD framework设置GCC_PREPROCESSOR_DEFINITIONS = "XCTESTWD_PORT=$(XCTESTWD_PORT)"