### PR TITLE
auto find iOS Simulator

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -112,7 +112,7 @@ if (_.isExistedDir(latestDir)) {
   throw _.chalk.red('Carthage is not existed, please reinstall!');
 }
 
-if (/^\s*(iPhone \d+).+?$/m.test(shelljs.exec('xcrun simctl list devices available', { silent: true }).grep('iPhone').head({ '-n': 1 }).stdout)) {
+if (/^\s*(iPhone .+?) \(/m.test(shelljs.exec('xcrun simctl list devices available', { silent: true }).grep('iPhone').head({ '-n': 1 }).stdout)) {
   const name = RegExp.$1;
 
   // execute build of xctestrun file:

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -111,12 +111,19 @@ if (_.isExistedDir(latestDir)) {
 } else {
   throw _.chalk.red('Carthage is not existed, please reinstall!');
 }
-// execute build of xctestrun file:
-shelljs.echo('preparing xctestrun build');
-shelljs.exec('xcodebuild build -project \"XCTestWD/XCTestWD.xcodeproj\" -scheme \"XCTestWDUITests\" -destination \"platform=iOS Simulator,name=iPhone 7\" -derivedDataPath \"XCTestWD/build\"');
 
-// fetch out potential
-let result = fs.readdirSync(path.join(__dirname, '..', 'XCTestWD', 'build', 'Build', 'Products')).filter(fn => fn.match('.*simulator.*\.xctestrun')).shift();
-console.log(`simulator optimization .xctestrun file generated: ${result}`);
+if (/^\s*(iPhone \d+).+?$/m.test(shelljs.exec('xcrun simctl list devices available', { silent: true }).grep('iPhone').head({ '-n': 1 }).stdout)) {
+  const name = RegExp.$1;
 
-updateInformation();
+  // execute build of xctestrun file:
+  shelljs.echo('preparing xctestrun build');
+  shelljs.exec('xcodebuild build -project "XCTestWD/XCTestWD.xcodeproj" -scheme "XCTestWDUITests" -destination "platform=iOS Simulator,name=' + name + '" -derivedDataPath "XCTestWD/build"');
+
+  // fetch out potential
+  let result = fs.readdirSync(path.join(__dirname, '..', 'XCTestWD', 'build', 'Build', 'Products')).filter(fn => fn.match('.*simulator.*\.xctestrun')).shift();
+  console.log(`simulator optimization .xctestrun file generated: ${result}`);
+
+  updateInformation();
+} else {
+  throw _.chalk.red('Failed to find iOS Simulator!');
+}


### PR DESCRIPTION
自动查找可用的 `iOS` 模拟器, 以代替固定的 `iPhone 7`,  目前升级到 `XCode 11` 之后里面已经没有 `iPhon 7` 这个型号了.

![image](https://user-images.githubusercontent.com/1265888/66752050-13d0df80-eec3-11e9-8ba2-58d4e3b60707.png)
