### PR TITLE
fix: allow install.js script to accept simulator name with different generation

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -131,7 +131,7 @@ if (_.isExistedDir(latestDir)) {
   throw _.chalk.red('Carthage is not existed, please reinstall!');
 }
 
-if (/^\s*(iPhone .+?) \(/m.test(shelljs.exec('xcrun simctl list devices', { silent: true }).grep('iPhone').head({ '-n': 1 }).stdout)) {
+if (/^\s*(iPhone .+?) \(.{8}-.{4}-.{4}-.{4}-.{12}\)/m.test(shelljs.exec('xcrun simctl list devices', { silent: true }).grep('iPhone').head({ '-n': 1 }).stdout)) {
   const name = RegExp.$1;
 
   // execute build of xctestrun file:


### PR DESCRIPTION
xcode: 14.2
mac os: ventura 13.2

The current script will produce this error
```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
		{ platform:iOS Simulator, OS:latest, name:iPhone SE }

	The requested device could not be found because no available devices matched the request.

	Available destinations for the "XCTestWDUITests" scheme:
		{ platform:macOS, arch:arm64, variant:Mac Catalyst, id:00006000-0014283821C3801E }
		{ platform:macOS, arch:x86_64, variant:Mac Catalyst, id:00006000-0014283821C3801E }
		{ platform:macOS, arch:arm64, variant:Designed for [iPad,iPhone], id:00006000-0014283821C3801E }
		{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
		{ platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }
		{ platform:macOS, variant:Mac Catalyst, name:Any Mac }
		{ platform:iOS Simulator, id:885F08DB-ED7E-48E5-836D-21FAB9EE95ED, OS:16.2, name:iPad (10th generation) }
		{ platform:iOS Simulator, id:34116270-CBA6-4D4C-8C06-6DA70D2D7E2F, OS:16.2, name:iPad Air (5th generation) }
		{ platform:iOS Simulator, id:DC8E482F-C906-4B8E-9985-184E6258BDD0, OS:16.2, name:iPad Pro (11-inch) (4th generation) }
		{ platform:iOS Simulator, id:6A355C7A-AF43-42DF-BD9A-9DDBEBFC292D, OS:16.2, name:iPad Pro (12.9-inch) (6th generation) }
		{ platform:iOS Simulator, id:163AAB41-0783-4A61-B7B4-F13E691F2F52, OS:16.2, name:iPad mini (6th generation) }
		{ platform:iOS Simulator, id:9A75BBBD-4B7F-4048-ADE9-45495AE0450E, OS:16.2, name:iPhone 14 }
		{ platform:iOS Simulator, id:F318F448-2588-41B4-A535-8DABDB498F63, OS:16.2, name:iPhone 14 Plus }
		{ platform:iOS Simulator, id:AF288CF8-0E58-405A-A49D-B87AE05D874F, OS:16.2, name:iPhone 14 Pro }
		{ platform:iOS Simulator, id:86AD4483-CAB0-46CB-BBAA-8425D3F2F3BA, OS:16.2, name:iPhone 14 Pro Max }
		{ platform:iOS Simulator, id:A1D8AC7F-578C-4E1C-933B-5181D0767F7A, OS:16.2, name:iPhone SE (3rd generation) }
```

The name should be `iPhone SE (3rd generation)`.
I changed the script to be able to take the correct name.
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/20050417/214386910-95d4c68c-366c-4a71-acf2-f4701311d09b.png">

If you have a better regex, it's very welcome.
